### PR TITLE
Feature/19 range selection functional

### DIFF
--- a/qtgui/SourceImage.cpp
+++ b/qtgui/SourceImage.cpp
@@ -10,6 +10,7 @@ namespace
   qreal boundedMin(qreal val1, qreal val2, qreal boundary);
   qreal boundedMax(qreal val1, qreal val2, qreal boundary);
   void adjustToAspectRatio(const QPointF& topLeft, QPointF& bottomRight, double targetAspectRatio, const QRectF& bounds);
+  QString pointsToClippingInfo(const QPointF& topLeft, const QPointF& bottomRight);
 }
 
 SourceImage::SourceImage(QQuickItem* parent)
@@ -162,6 +163,15 @@ int SourceImage::clipY() const
   return clipTopLeft.y();
 }
 
+QString SourceImage::clippingInfo() const
+{
+  if (newStartingPoint.x() >= 0)
+  {
+    return pointsToClippingInfo(newClipTopLeft, newClipBottomRight);
+  }
+  return pointsToClippingInfo(clipTopLeft, clipBottomRight);
+}
+
 void SourceImage::normalizeLocations()
 {
   double definedAspectRatio = (1. * resultSize.y()) / resultSize.x();
@@ -175,6 +185,13 @@ void SourceImage::normalizeLocations()
   clipTopLeft.setY(topLeft.y() * image.height() / bounds.height());
   clipBottomRight.setX(bottomRight.x() * image.width() / bounds.width());
   clipBottomRight.setY(bottomRight.y() * image.height() / bounds.height());
+
+  newClipTopLeft.setX(newTopLeft.x() * image.width() / bounds.width());
+  newClipTopLeft.setY(newTopLeft.y() * image.height() / bounds.height());
+  newClipBottomRight.setX(newBottomRight.x() * image.width() / bounds.width());
+  newClipBottomRight.setY(newBottomRight.y() * image.height() / bounds.height());
+
+  newClipping();
 }
 
 namespace
@@ -228,5 +245,9 @@ namespace
         bottomRight.setY(topLeft.y() + actualWidth / targetAspectRatio);
       }
     }
+  }
+  QString pointsToClippingInfo(const QPointF& topLeft, const QPointF& bottomRight)
+  {
+    return QString("Use " + QString::number(topLeft.x()) + ", " + QString::number(topLeft.y()) + " (w:" + QString::number(bottomRight.x() - topLeft.x()) + ", h:" + QString::number(bottomRight.y() - topLeft.y()) + ")");
   }
 }

--- a/qtgui/SourceImage.h
+++ b/qtgui/SourceImage.h
@@ -15,6 +15,7 @@ class SourceImage : public QQuickPaintedItem
     Q_PROPERTY(int clipY READ clipY)
     Q_PROPERTY(int clipWidth READ clipWidth)
     Q_PROPERTY(int clipHeight READ clipHeight)
+    Q_PROPERTY(QString clippingInfo READ clippingInfo NOTIFY newClipping)
 public:
   SourceImage(QQuickItem* parent = nullptr);
   Q_INVOKABLE void setPath(const QUrl& path);
@@ -26,12 +27,14 @@ public:
   int clipHeight() const;
   int clipX() const;
   int clipY() const;
+  QString clippingInfo() const;
   
 signals:
   void dataChanged();
   void pathChanged();
   void widthChanged();
   void heightChanged();
+  void newClipping();
 
 protected:
   void mousePressEvent(QMouseEvent* theEvent) final;
@@ -45,6 +48,8 @@ private:
   QPoint resultSize;
   QPoint clipTopLeft;
   QPoint clipBottomRight;
+  QPoint newClipTopLeft;
+  QPoint newClipBottomRight;
   QImage image;
   QPointF topLeft;
   QPointF bottomRight;

--- a/qtgui/SourceImage.h
+++ b/qtgui/SourceImage.h
@@ -48,6 +48,7 @@ private:
   QImage image;
   QPointF topLeft;
   QPointF bottomRight;
+  QPointF newStartingPoint;
   QPointF newTopLeft;
   QPointF newBottomRight;
   bool abort;

--- a/qtgui/resources/ApplicationWindow.qml
+++ b/qtgui/resources/ApplicationWindow.qml
@@ -79,6 +79,10 @@ ApplicationWindow {
         pixelator.setStitchColors(pixelColors.colors)
         pixelator.run()
       }
+      onClippingSizeChanged:
+      {
+        footer.update
+      }
     }
     Component.onCompleted:
     {
@@ -91,6 +95,12 @@ ApplicationWindow {
     onPixelationCreated:
     {
       imagePreview.outputImage.setData(pixelator.resultImage)
+    }
+  }
+  footer: ToolBar {
+    RowLayout {
+      anchors.fill: parent
+      Label { text: imagePreview.clippingInfo }
     }
   }
 }

--- a/qtgui/resources/FileDisplay.qml
+++ b/qtgui/resources/FileDisplay.qml
@@ -27,6 +27,7 @@ Frame {
       SplitView.minimumWidth: 200
       SplitView.preferredWidth: 400
       SplitView.maximumWidth: 600
+
     }
 
     ResultImage {
@@ -41,10 +42,13 @@ Frame {
   function getInputFile() {inputFileGet.open()}
   function getOutputFile() {outputFileGet.open()}
   property var input: inputImage
+  property string clippingInfo: inputImage.clippingInfo
   signal inputDataChanged()
+  signal clippingSizeChanged()
 
   Component.onCompleted:
   {
     inputImage.pathChanged.connect(inputDataChanged)
+    inputImage.newClipping.connect(clippingSizeChanged)
   }
 }

--- a/qtgui/resources/FileDisplay.qml
+++ b/qtgui/resources/FileDisplay.qml
@@ -27,7 +27,6 @@ Frame {
       SplitView.minimumWidth: 200
       SplitView.preferredWidth: 400
       SplitView.maximumWidth: 600
-
     }
 
     ResultImage {


### PR DESCRIPTION
this pull request fixes #19 
actually fixed: 
- the selection range doesn't move around; the toplevel corner stays set all the way.
- if one dimension would exceed image bounds, the selection is trimmed, retaining aspect ratio.
- it is possible to select in the topleft corner of the first clicked point, too. 
- there is a status bar at the bottom indicating the target file size and region's topleft point in target file coordinates. 
still there: 
- slight selection range hops on trimmed clipping ranges, mild rounding errors on pixels (to be investigated)
- image size is not trimmed to visible window, and there are no scroll bars. -> #20 